### PR TITLE
근처 실종된 동물 리스트 가져오기 기능 구현

### DIFF
--- a/src/main/java/com/ktc/togetherPet/config/property/KakaoProperties.java
+++ b/src/main/java/com/ktc/togetherPet/config/property/KakaoProperties.java
@@ -3,11 +3,14 @@ package com.ktc.togetherPet.config.property;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("kakao")
-public record KakaoProperties(String clientId,
-                              String redirectUrl,
-                              String loginUrl,
-                              String tokenUrl,
-                              String userInfoUrl,
-                              String messageUrl) {
+public record KakaoProperties(
+    String clientId,
+    String redirectUrl,
+    String loginUrl,
+    String tokenUrl,
+    String userInfoUrl,
+    String messageUrl,
+    String administrativeUrl
+) {
 
 }

--- a/src/main/java/com/ktc/togetherPet/controller/MissingController.java
+++ b/src/main/java/com/ktc/togetherPet/controller/MissingController.java
@@ -1,15 +1,20 @@
 package com.ktc.togetherPet.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 
 import com.ktc.togetherPet.annotation.OauthUser;
 import com.ktc.togetherPet.model.dto.missing.MissingPetDTO;
+import com.ktc.togetherPet.model.dto.missing.MissingPetNearByDTO;
 import com.ktc.togetherPet.model.dto.oauth.OauthUserDTO;
 import com.ktc.togetherPet.service.MissingService;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -30,5 +35,15 @@ public class MissingController {
 
         missingService.registerMissingPet(oauthUserDTO, missingPetDTO);
         return ResponseEntity.status(CREATED).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MissingPetNearByDTO>> getMissingPetsNearByRegion(
+        @RequestParam("latitude") float latitude,
+        @RequestParam("longitude") float longitude
+    ) {
+        return ResponseEntity
+            .status(OK)
+            .body(missingService.getMissingPetsNearBy(latitude, longitude));
     }
 }

--- a/src/main/java/com/ktc/togetherPet/model/dto/kakaoMap/Documents.java
+++ b/src/main/java/com/ktc/togetherPet/model/dto/kakaoMap/Documents.java
@@ -1,0 +1,22 @@
+package com.ktc.togetherPet.model.dto.kakaoMap;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(SnakeCaseStrategy.class)
+record Documents(
+    String regionType,
+    String addressName,
+    String region1depthName,
+    String region2depthName,
+    String region3depthName,
+    String region4depthName,
+    String code,
+    double x,
+    double y
+) {
+
+    public boolean isRegionTypeH() {
+        return regionType.equals("H");
+    }
+}

--- a/src/main/java/com/ktc/togetherPet/model/dto/kakaoMap/LocationFromKakaoDTO.java
+++ b/src/main/java/com/ktc/togetherPet/model/dto/kakaoMap/LocationFromKakaoDTO.java
@@ -1,0 +1,31 @@
+package com.ktc.togetherPet.model.dto.kakaoMap;
+
+import static com.ktc.togetherPet.exception.CustomException.invalidLocaltionException;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record LocationFromKakaoDTO(
+    MetaDTO meta,
+    List<Documents> documents
+) {
+
+    public String getAdministrative3rdDepthName() {
+        return getAdministrativeDocuments().region3depthName();
+    }
+
+    public long getAdministrativeCode() {
+        return Integer.parseInt(getAdministrativeDocuments().code());
+    }
+
+    private Documents getAdministrativeDocuments() {
+        for (Documents docs : documents) {
+            if (docs.isRegionTypeH()) {
+                return docs;
+            }
+        }
+        throw invalidLocaltionException();
+    }
+}

--- a/src/main/java/com/ktc/togetherPet/model/dto/kakaoMap/MetaDTO.java
+++ b/src/main/java/com/ktc/togetherPet/model/dto/kakaoMap/MetaDTO.java
@@ -1,0 +1,11 @@
+package com.ktc.togetherPet.model.dto.kakaoMap;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(SnakeCaseStrategy.class)
+record MetaDTO(
+    int totalCount
+) {
+
+}

--- a/src/main/java/com/ktc/togetherPet/model/dto/missing/MissingPetNearByDTO.java
+++ b/src/main/java/com/ktc/togetherPet/model/dto/missing/MissingPetNearByDTO.java
@@ -1,0 +1,14 @@
+package com.ktc.togetherPet.model.dto.missing;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record MissingPetNearByDTO(
+    long petId,
+    float latitude,
+    float longitude,
+    String petImageUrl
+) {
+
+}

--- a/src/main/java/com/ktc/togetherPet/model/entity/Missing.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/Missing.java
@@ -28,14 +28,14 @@ public class Missing {
     @Column(name = "is_missing", nullable = false)
     private Boolean isMissing;
 
-//    @Column(name = "timestamp", nullable = false)
-//    private LocalDateTime timestamp;
-
     @Embedded
     private DateTime lostTime;
 
     @Embedded
     private Location location;
+
+    @Column(name = "region_code", nullable = false)
+    private long regionCode;
 
     public Missing() {
     }
@@ -44,12 +44,22 @@ public class Missing {
         Pet pet,
         Boolean isMissing,
         DateTime dateTime,
-        Location location
+        Location location,
+        long regionCode
     ) {
         this.pet = pet;
         this.isMissing = isMissing;
         this.lostTime = dateTime;
         this.location = location;
+        this.regionCode = regionCode;
+    }
+
+    public Pet getPet() {
+        return pet;
+    }
+
+    public Location getLocation() {
+        return location;
     }
 
     @Override
@@ -57,22 +67,18 @@ public class Missing {
         if (this == o) {
             return true;
         }
-
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         Missing missing = (Missing) o;
-
-        return Objects.equals(id, missing.id)
-            && Objects.equals(pet, missing.pet)
-            && Objects.equals(isMissing, missing.isMissing)
-            && Objects.equals(lostTime, missing.lostTime)
+        return regionCode == missing.regionCode && Objects.equals(id, missing.id)
+            && Objects.equals(pet, missing.pet) && Objects.equals(isMissing,
+            missing.isMissing) && Objects.equals(lostTime, missing.lostTime)
             && Objects.equals(location, missing.location);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, pet, isMissing, lostTime, location);
+        return Objects.hash(id, pet, isMissing, lostTime, location, regionCode);
     }
 }

--- a/src/main/java/com/ktc/togetherPet/model/entity/Missing.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/Missing.java
@@ -62,6 +62,10 @@ public class Missing {
         return location;
     }
 
+    public boolean isMissing() {
+        return isMissing;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/com/ktc/togetherPet/model/entity/Pet.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/Pet.java
@@ -32,6 +32,10 @@ public class Pet {
     @Column(name = "is_neutering", nullable = true)
     private Boolean isNeutering;
 
+    public Long getId() {
+        return id;
+    }
+
     public Pet() {
     }
 

--- a/src/main/java/com/ktc/togetherPet/model/vo/Location.java
+++ b/src/main/java/com/ktc/togetherPet/model/vo/Location.java
@@ -20,6 +20,14 @@ public class Location {
         this.longitude = longitude;
     }
 
+    public float getLatitude() {
+        return latitude;
+    }
+
+    public float getLongitude() {
+        return longitude;
+    }
+
     private void validate(float latitude, float longitude) {
         if (!validateLatitude(latitude) || !validateLongitude(longitude)) {
             throw invalidLocaltionException();

--- a/src/main/java/com/ktc/togetherPet/repository/MissingRepository.java
+++ b/src/main/java/com/ktc/togetherPet/repository/MissingRepository.java
@@ -1,10 +1,12 @@
 package com.ktc.togetherPet.repository;
 
 import com.ktc.togetherPet.model.entity.Missing;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MissingRepository extends JpaRepository<Missing, Long> {
 
+    List<Missing> findAllByRegionCode(long regionCode);
 }

--- a/src/main/java/com/ktc/togetherPet/service/KakaoMapService.java
+++ b/src/main/java/com/ktc/togetherPet/service/KakaoMapService.java
@@ -1,0 +1,57 @@
+package com.ktc.togetherPet.service;
+
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpStatus.OK;
+
+import com.ktc.togetherPet.config.property.KakaoProperties;
+import com.ktc.togetherPet.exception.CustomException;
+import com.ktc.togetherPet.model.dto.kakaoMap.LocationFromKakaoDTO;
+import com.ktc.togetherPet.model.vo.Location;
+import java.net.URI;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+public class KakaoMapService {
+
+    private final KakaoProperties kakaoProperties;
+
+    private RestTemplate restTemplate = new RestTemplateBuilder().build();
+
+    public KakaoMapService(KakaoProperties kakaoProperties) {
+        this.kakaoProperties = kakaoProperties;
+    }
+
+    public long getRegionCodeFromKakao(Location location) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "KakaoAK " + kakaoProperties.clientId());
+        headers.add("Content-Type", "application/json");
+
+        URI uri = UriComponentsBuilder
+            .fromHttpUrl(kakaoProperties.administrativeUrl())
+            .queryParam("x", location.getLongitude())
+            .queryParam("y", location.getLatitude())
+            .build()
+            .toUri();
+
+        RequestEntity<Void> request = new RequestEntity<>(headers, GET, uri);
+        ResponseEntity<LocationFromKakaoDTO> response = restTemplate
+            .exchange(request, LocationFromKakaoDTO.class);
+
+        if (response.getStatusCode().isSameCodeAs(OK)) {
+            LocationFromKakaoDTO locationFromKakaoDTO = response.getBody();
+
+            assert locationFromKakaoDTO != null;
+            return locationFromKakaoDTO.getAdministrativeCode();
+        }
+        throw CustomException.invalidApiException(
+            HttpStatus.resolve(response.getStatusCode().value())
+        );
+    }
+}

--- a/src/main/java/com/ktc/togetherPet/service/MissingService.java
+++ b/src/main/java/com/ktc/togetherPet/service/MissingService.java
@@ -79,6 +79,7 @@ public class MissingService {
 
         return missingRepository.findAllByRegionCode(regionCode)
             .stream()
+            .filter(Missing::isMissing)
             .map(missing -> new MissingPetNearByDTO(
                 missing.getPet().getId(),
                 missing.getLocation().getLatitude(),

--- a/src/main/java/com/ktc/togetherPet/service/MissingService.java
+++ b/src/main/java/com/ktc/togetherPet/service/MissingService.java
@@ -2,6 +2,7 @@ package com.ktc.togetherPet.service;
 
 import com.ktc.togetherPet.exception.CustomException;
 import com.ktc.togetherPet.model.dto.missing.MissingPetDTO;
+import com.ktc.togetherPet.model.dto.missing.MissingPetNearByDTO;
 import com.ktc.togetherPet.model.dto.oauth.OauthUserDTO;
 import com.ktc.togetherPet.model.entity.Missing;
 import com.ktc.togetherPet.model.entity.Pet;
@@ -13,6 +14,7 @@ import com.ktc.togetherPet.repository.BreedRepository;
 import com.ktc.togetherPet.repository.MissingRepository;
 import com.ktc.togetherPet.repository.PetRepository;
 import com.ktc.togetherPet.repository.UserRepository;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 
@@ -23,17 +25,20 @@ public class MissingService {
     private final UserRepository userRepository;
     private final PetRepository petRepository;
     private final BreedRepository breedRepository;
+    private final KakaoMapService kakaoMapService;
 
     public MissingService(
         MissingRepository missingRepository,
         UserRepository userRepository,
         PetRepository petRepository,
-        BreedRepository breedRepository
+        BreedRepository breedRepository,
+        KakaoMapService kakaoMapService
     ) {
         this.missingRepository = missingRepository;
         this.userRepository = userRepository;
         this.petRepository = petRepository;
         this.breedRepository = breedRepository;
+        this.kakaoMapService = kakaoMapService;
     }
 
     public void registerMissingPet(OauthUserDTO oauthUserDTO, MissingPetDTO missingPetDTO) {
@@ -53,16 +58,33 @@ public class MissingService {
                 )
             );
 
+        Location location = new Location(
+            missingPetDTO.latitude(),
+            missingPetDTO.longitude()
+        );
+
         missingRepository.save(
             new Missing(
                 pet,
                 true,
                 new DateTime(missingPetDTO.lostTime()),
-                new Location(
-                    missingPetDTO.latitude(),
-                    missingPetDTO.longitude()
-                )
+                location,
+                kakaoMapService.getRegionCodeFromKakao(location)
             )
         );
+    }
+
+    public List<MissingPetNearByDTO> getMissingPetsNearBy(float latitude, float longitude) {
+        long regionCode = kakaoMapService.getRegionCodeFromKakao(new Location(latitude, longitude));
+
+        return missingRepository.findAllByRegionCode(regionCode)
+            .stream()
+            .map(missing -> new MissingPetNearByDTO(
+                missing.getPet().getId(),
+                missing.getLocation().getLatitude(),
+                missing.getLocation().getLongitude(),
+                //TODO pet-image-url을 실제 경로로 받아오도록 수정해야함.
+                "pet-image-url"
+            )).toList();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,4 @@ kakao.message-url=${kakao.message-url}
 kakao.redirect-url=${kakao.redirect-url}
 kakao.token-url=${kakao.token-url}
 kakao.user-info-url=${kakao.user-info-url}
+kakao.administrative-url=${kakao.administrative-url}

--- a/src/test/java/com/ktc/togetherPet/service/MissingServiceTest.java
+++ b/src/test/java/com/ktc/togetherPet/service/MissingServiceTest.java
@@ -64,6 +64,9 @@ class MissingServiceTest {
     @Mock
     private BreedRepository breedRepository;
 
+    @Mock
+    private KakaoMapService kakaoMapService;
+
     @InjectMocks
     private MissingService missingService;
 
@@ -76,6 +79,8 @@ class MissingServiceTest {
         private Missing missing;
         private Pet pet;
         private Breed breed;
+        private Location location;
+        private long regionCode;
 
         @BeforeEach
         void setUp() {
@@ -105,14 +110,19 @@ class MissingServiceTest {
                 missingPetDTO.isNeutering()
             );
 
+            location = new Location(
+                missingPetDTO.latitude(),
+                missingPetDTO.longitude()
+            );
+
+            regionCode = 1;
+
             missing = new Missing(
                 pet,
                 true,
                 new DateTime(missingPetDTO.lostTime()),
-                new Location(
-                    missingPetDTO.latitude(),
-                    missingPetDTO.longitude()
-                )
+                location,
+                regionCode
             );
         }
 
@@ -133,6 +143,9 @@ class MissingServiceTest {
 
                 given(missingRepository.save(missing))
                     .willReturn(missing);
+
+                given(kakaoMapService.getRegionCodeFromKakao(location))
+                    .willReturn(regionCode);
 
                 //then
                 missingService.registerMissingPet(oauthUserDTO, missingPetDTO);
@@ -166,6 +179,8 @@ class MissingServiceTest {
                 given(breedRepository.findByName(missingPetDTO.petBreed()))
                     .willReturn(Optional.ofNullable(breed));
 
+                given(kakaoMapService.getRegionCodeFromKakao(location))
+                    .willReturn(regionCode);
                 //then
                 missingService.registerMissingPet(oauthUserDTO, missingPetDTO);
 


### PR DESCRIPTION
## 📋 작업 개요
<!-- 여기에 작업한 내용을 간략하게 요약해 주세요 -->
실종된 근처 동물의 정보를 가져오는 API 구현

## 📝 작업 상세 설명
<!-- 구체적인 변경 사항을 적어주세요 -->
위도와 경도를 입력받아 해당 [Kakao 행정구역 찾기](https://developers.kakao.com/docs/latest/ko/local/dev-guide#coord-to-district)를 통해 행정구역을 찾아 해당 행정구역에 포함되는 모든 실종 동물의 리스트를 반환하도록 했습니다.
위의 API 사용을 위해 Kakao Properties에 ```administrativeUrl```이 추가되었습니다.
```Missing```엔티티에 ```regionCode```라는 필드가 추가했습니다.

### ✅ 체크리스트
- [x] 모든 테스트를 통과했나요?
- [x] 커밋 컨벤션에 맞춰서 작성 했나요?
- [x] PR을 요청할 브랜치를 제대로 선택했나요?
- [x] 이전의 업데이트 사항을 전부 반영했나요?

### 🔗 관련 이슈
<!-- 이슈 번호를 링크하세요: #이슈번호 -->
resolved #13 

### 📚 참고 사항
<!-- 리뷰어가 참고할 만한 내용이 있다면 적어주세요 -->
