### PR TITLE
실종 제보 기능 구현

### DIFF
--- a/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
+++ b/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
@@ -1,7 +1,10 @@
 package com.ktc.togetherPet.controller;
 
+import com.ktc.togetherPet.annotation.OauthUser;
+import com.ktc.togetherPet.model.dto.oauth.OauthUserDTO;
 import com.ktc.togetherPet.model.dto.suspect.SuspectRequestDTO;
 import com.ktc.togetherPet.service.SuspectService;
+import java.io.IOException;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -25,11 +28,10 @@ public class SuspectController {
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> createSuspect(
         @RequestPart SuspectRequestDTO suspectRequestDTO,
-        @RequestPart(required = false) List<MultipartFile> files
+        @RequestPart(required = false) List<MultipartFile> files,
+        @OauthUser OauthUserDTO oauthUserDTO
         ) {
-        /** todo: MultipartFile에 대한 통일성을 지켜야 함. 이 부분 팀원들에게 고지
-         */
-        suspectService.createMissing(suspectRequestDTO, files);
+        suspectService.createMissing(oauthUserDTO, suspectRequestDTO, files);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
+++ b/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
@@ -30,7 +30,7 @@ public class SuspectController {
         @RequestPart SuspectRequestDTO suspectRequestDTO,
         @RequestPart(required = false) List<MultipartFile> files,
         @OauthUser OauthUserDTO oauthUserDTO
-        ) {
+        ) throws IOException {
         suspectService.createMissing(oauthUserDTO, suspectRequestDTO, files);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/main/java/com/ktc/togetherPet/exception/CustomException.java
+++ b/src/main/java/com/ktc/togetherPet/exception/CustomException.java
@@ -8,6 +8,7 @@ import static com.ktc.togetherPet.exception.ErrorMessage.INVALID_PET_MONTH;
 import static com.ktc.togetherPet.exception.ErrorMessage.INVALID_USER;
 import static com.ktc.togetherPet.exception.ErrorMessage.PET_NOT_FOUND;
 import static com.ktc.togetherPet.exception.ErrorMessage.MISSING_NOT_FOUND;
+import static com.ktc.togetherPet.exception.ErrorMessage.REPORT_NOT_FOUND;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
@@ -69,6 +70,10 @@ public class CustomException extends RuntimeException {
 
     public static CustomException invalidDateException() {
         return new CustomException(INVALID_DATE, BAD_REQUEST);
+    }
+
+    public static CustomException reportNotFoundException() {
+        return new CustomException(REPORT_NOT_FOUND, NOT_FOUND);
     }
 
     public static CustomException missingNotFound(){

--- a/src/main/java/com/ktc/togetherPet/exception/ErrorMessage.java
+++ b/src/main/java/com/ktc/togetherPet/exception/ErrorMessage.java
@@ -14,4 +14,5 @@ public class ErrorMessage {
     public static final String BREED_NOT_FOUND = "해당 종을 찾을 수 없습니다.";
     public static final String PET_NOT_FOUND = "해당 펫을 찾을 수 없습니다.";
     public static final String MISSING_NOT_FOUND = "해당 실종 정보를 찾을 수 없습니다.";
+    public static final String REPORT_NOT_FOUND = "해당 신고 정보를 찾을 수 없습니다.";
 }

--- a/src/main/java/com/ktc/togetherPet/model/dto/suspect/SuspectRequestDTO.java
+++ b/src/main/java/com/ktc/togetherPet/model/dto/suspect/SuspectRequestDTO.java
@@ -19,7 +19,8 @@ public record SuspectRequestDTO(
     LocalDateTime foundDate,
 
     String breed,
-    String gender
+    String gender,
+    Long missingId
 ) {
 
 }

--- a/src/main/java/com/ktc/togetherPet/model/dto/suspect/SuspectRequestDTO.java
+++ b/src/main/java/com/ktc/togetherPet/model/dto/suspect/SuspectRequestDTO.java
@@ -1,17 +1,22 @@
 package com.ktc.togetherPet.model.dto.suspect;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
+@JsonNaming(SnakeCaseStrategy.class)
 public record SuspectRequestDTO(
-
-    @NotNull
-    String species,
     @NotNull
     String color,
     @NotNull
-    Float found_latitude,
+    Float foundLatitude,
     @NotNull
-    Float found_longitude,
+    Float foundLongitude,
+    @NotNull
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    LocalDateTime foundDate,
 
     String breed,
     String gender

--- a/src/main/java/com/ktc/togetherPet/model/entity/ImageRelation/ImageRelation.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/ImageRelation/ImageRelation.java
@@ -2,6 +2,7 @@ package com.ktc.togetherPet.model.entity.ImageRelation;
 
 
 import com.ktc.togetherPet.model.entity.Image;
+import com.ktc.togetherPet.model.entity.Report;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -9,6 +10,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -25,8 +28,14 @@ public class ImageRelation {
     @Column(name = "image_entity_type", nullable = false)
     private ImageEntityType imageEntityType;
 
+    @ManyToOne
+    @JoinColumn(name = "report_id", nullable = true)
+    private Report report;
+
+    /**
     @Column(name = "entity_id", nullable = false)
     private Long entityId;
+     **/
 
     @ManyToOne(targetEntity = Image.class)
     @JoinColumn(name = "image_id", nullable = false)
@@ -35,9 +44,8 @@ public class ImageRelation {
     public ImageRelation() {
     }
 
-    public ImageRelation(ImageEntityType imageEntityType, Long entityId, Image image) {
+    public ImageRelation(ImageEntityType imageEntityType, Image image) {
         this.imageEntityType = imageEntityType;
-        this.entityId = entityId;
         this.image = image;
     }
 }

--- a/src/main/java/com/ktc/togetherPet/model/entity/ImageRelation/ImageRelation.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/ImageRelation/ImageRelation.java
@@ -28,11 +28,12 @@ public class ImageRelation {
     @Column(name = "image_entity_type", nullable = false)
     private ImageEntityType imageEntityType;
 
+    //todo: Report, Pet, Missing 연관 관계를 entity_id로 통합 관리하도록 해야함
     @ManyToOne
     @JoinColumn(name = "report_id", nullable = true)
     private Report report;
 
-    /**
+    /**todo: Report, Pet, Missing 연관 관계를 entity_id로 통합 관리하도록 해야함
     @Column(name = "entity_id", nullable = false)
     private Long entityId;
      **/

--- a/src/main/java/com/ktc/togetherPet/model/entity/ImageRelation/ImageRelation.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/ImageRelation/ImageRelation.java
@@ -10,8 +10,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;

--- a/src/main/java/com/ktc/togetherPet/model/entity/Report.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/Report.java
@@ -1,10 +1,7 @@
 package com.ktc.togetherPet.model.entity;
 
-import com.ktc.togetherPet.model.entity.ImageRelation.ImageRelation;
 import com.ktc.togetherPet.model.vo.Location;
-import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/ktc/togetherPet/model/entity/Report.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/Report.java
@@ -19,7 +19,7 @@ public class Report {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long reportId;
+    private Long id;
 
     @OneToOne(targetEntity = User.class)
     @JoinColumn(name = "user_id", nullable = false)
@@ -32,16 +32,15 @@ public class Report {
     private Location location;
 
     @ManyToOne(targetEntity = Missing.class)
-    @JoinColumn(name = "mssing_id", nullable = true)
+    @JoinColumn(name = "missing_id", nullable = true)
     private Missing missing;
 
     public Report() {
     }
 
-    public Report(User user, LocalDateTime timestamp, Location location, Missing missing) {
+    public Report(User user, LocalDateTime timestamp, Location location) {
         this.user = user;
         this.timeStamp = timestamp;
         this.location = location;
-        this.missing = missing;
     }
 }

--- a/src/main/java/com/ktc/togetherPet/model/entity/Report.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/Report.java
@@ -1,7 +1,10 @@
 package com.ktc.togetherPet.model.entity;
 
+import com.ktc.togetherPet.model.entity.ImageRelation.ImageRelation;
 import com.ktc.togetherPet.model.vo.Location;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -31,9 +34,32 @@ public class Report {
     @Embedded
     private Location location;
 
+    @Column(name = "color", nullable = true)
+    private String color;
+
+    @ManyToOne(targetEntity = Breed.class)
+    @JoinColumn(name = "breed_id", nullable = true)
+    private Breed breed;
+
     @ManyToOne(targetEntity = Missing.class)
     @JoinColumn(name = "missing_id", nullable = true)
     private Missing missing;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setBreed(Breed breed) {
+        this.breed = breed;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public void setMissing(Missing missing) {
+        this.missing = missing;
+    }
 
     public Report() {
     }

--- a/src/main/java/com/ktc/togetherPet/repository/ImageRelationRepository.java
+++ b/src/main/java/com/ktc/togetherPet/repository/ImageRelationRepository.java
@@ -1,0 +1,10 @@
+package com.ktc.togetherPet.repository;
+
+import com.ktc.togetherPet.model.entity.ImageRelation.ImageRelation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImageRelationRepository extends JpaRepository<ImageRelation, Long> {
+
+}

--- a/src/main/java/com/ktc/togetherPet/repository/ImageRepository.java
+++ b/src/main/java/com/ktc/togetherPet/repository/ImageRepository.java
@@ -1,0 +1,10 @@
+package com.ktc.togetherPet.repository;
+
+import com.ktc.togetherPet.model.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+}

--- a/src/main/java/com/ktc/togetherPet/service/ImageService.java
+++ b/src/main/java/com/ktc/togetherPet/service/ImageService.java
@@ -72,6 +72,7 @@ public class ImageService {
             Image image = new Image(imageFilePath);
             Image savedImage = imageRepository.save(image);
 
+            //todo: 이것도 지우고 QueryDSL로 report와 연관짓도록 하기
             Report report = reportRepository.findById(reportId)
                 .orElseThrow(CustomException::reportNotFoundException);
 

--- a/src/main/java/com/ktc/togetherPet/service/ImageService.java
+++ b/src/main/java/com/ktc/togetherPet/service/ImageService.java
@@ -1,7 +1,17 @@
 package com.ktc.togetherPet.service;
 
+import com.ktc.togetherPet.exception.CustomException;
+import com.ktc.togetherPet.model.entity.Image;
+import com.ktc.togetherPet.model.entity.ImageRelation.ImageEntityType;
+import com.ktc.togetherPet.model.entity.ImageRelation.ImageRelation;
+import com.ktc.togetherPet.model.entity.Report;
+import com.ktc.togetherPet.repository.ImageRelationRepository;
+import com.ktc.togetherPet.repository.ImageRepository;
+import com.ktc.togetherPet.repository.ReportRepository;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -9,8 +19,23 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 public class ImageService {
 
+    private final ImageRepository imageRepository;
+    private final ReportRepository reportRepository;
+    private final ImageRelationRepository imageRelationRepository;
+
+    public ImageService(ImageRepository imageRepository, ReportRepository reportRepository, ImageRelationRepository imageRelationRepository) {
+        this.imageRepository = imageRepository;
+        this.reportRepository = reportRepository;
+        this.imageRelationRepository = imageRelationRepository;
+    }
+
     @Value("${image-folder-path}")
     private String FOLDER_PATH;
+
+    // TODO: 매개변수로 path를 받아서 좀 더 유동적인 이미지 저장 방식을 구현할 수 있도록 변경해야할 듯
+    // 지금 saveImage 메서드는 petId를 받아서 이미지를 저장하는 방식으로 구현되어 있음
+    // saveImages 메서드는 reportId를 받아서 이미지를 저장하는 방식으로 구현되어 있음
+    // 두 개의 기능이 중복되어있어 petId는 path/pet/ 에 저장되고 reportId는 path/report/ 에 저장되는 형태로 구현하는 게 좋을 것 같음
 
     public String saveImage(Long petId, MultipartFile petImage) throws IOException {
         File directory = new File(FOLDER_PATH);
@@ -26,6 +51,33 @@ public class ImageService {
         petImage.transferTo(file);
 
         return imageFilePath;
+    }
+
+    public void saveImages(Long reportId, List<MultipartFile> files) throws IOException {
+
+        File directory = new File(FOLDER_PATH + "/report/");
+
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
+        for (int i = 0; i < files.size(); i++) {
+            MultipartFile file = files.get(i);
+            String extension = getFileExtension(file.getOriginalFilename());
+            String imageFileName = reportId + "_" + i + extension;
+            String imageFilePath = FOLDER_PATH + "/report/" + imageFileName;
+
+            File imageFile = new File(imageFilePath);
+            file.transferTo(imageFile);
+
+            Image image = new Image(imageFilePath);
+            Image savedImage = imageRepository.save(image);
+
+            Report report = reportRepository.findById(reportId)
+                .orElseThrow(CustomException::reportNotFoundException);
+
+            ImageRelation imageRelation = new ImageRelation(ImageEntityType.REPORT, savedImage);
+            imageRelationRepository.save(imageRelation);
+        }
     }
 
     private String getFileExtension(String filename) {

--- a/src/main/java/com/ktc/togetherPet/service/ImageService.java
+++ b/src/main/java/com/ktc/togetherPet/service/ImageService.java
@@ -10,7 +10,6 @@ import com.ktc.togetherPet.repository.ImageRepository;
 import com.ktc.togetherPet.repository.ReportRepository;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/ktc/togetherPet/service/ReportService.java
+++ b/src/main/java/com/ktc/togetherPet/service/ReportService.java
@@ -1,5 +1,13 @@
 package com.ktc.togetherPet.service;
 
+import com.ktc.togetherPet.exception.CustomException;
+import com.ktc.togetherPet.model.dto.suspect.SuspectRequestDTO;
+import com.ktc.togetherPet.model.entity.Breed;
+import com.ktc.togetherPet.model.entity.Missing;
+import com.ktc.togetherPet.model.entity.Report;
+import com.ktc.togetherPet.model.entity.User;
+import com.ktc.togetherPet.model.vo.Location;
+import com.ktc.togetherPet.repository.MissingRepository;
 import com.ktc.togetherPet.repository.ReportRepository;
 import org.springframework.stereotype.Service;
 
@@ -7,8 +15,28 @@ import org.springframework.stereotype.Service;
 public class ReportService {
 
     private final ReportRepository reportRepository;
+    private final MissingRepository missingRepository;
 
-    public ReportService(ReportRepository reportRepository) {
+    public ReportService(ReportRepository reportRepository, MissingRepository missingRepository) {
         this.reportRepository = reportRepository;
+        this.missingRepository = missingRepository;
+    }
+
+    public Long createReport(User user, SuspectRequestDTO suspectRequestDTO) {
+
+        Location location = new Location(
+            suspectRequestDTO.foundLatitude(),
+            suspectRequestDTO.foundLongitude()
+        );
+
+        Report report = reportRepository.save(
+            new Report(
+                user,
+                suspectRequestDTO.foundDate(),
+                location
+            )
+        );
+
+        return report.getId();
     }
 }

--- a/src/main/java/com/ktc/togetherPet/service/ReportService.java
+++ b/src/main/java/com/ktc/togetherPet/service/ReportService.java
@@ -39,4 +39,35 @@ public class ReportService {
 
         return report.getId();
     }
+
+    public void setBreed(Long reportId, String breed) {
+        Report report = reportRepository.findById(reportId)
+            .orElseThrow(CustomException::reportNotFoundException);
+        Breed breedEntity = new Breed(breed);
+
+        report.setBreed(breedEntity);
+
+        reportRepository.save(report);
+    }
+
+    public void setColor(Long reportId, String color) {
+        Report report = reportRepository.findById(reportId)
+            .orElseThrow(CustomException::reportNotFoundException);
+
+        report.setColor(color);
+
+        reportRepository.save(report);
+    }
+
+    public void setMissing(Long reportId, Long missingId) {
+        Report report = reportRepository.findById(reportId)
+            .orElseThrow(CustomException::reportNotFoundException);
+
+        Missing missing = missingRepository.findById(missingId)
+            .orElseThrow(CustomException::missingNotFound);
+
+        report.setMissing(missing);
+
+        reportRepository.save(report);
+    }
 }

--- a/src/main/java/com/ktc/togetherPet/service/ReportService.java
+++ b/src/main/java/com/ktc/togetherPet/service/ReportService.java
@@ -1,0 +1,14 @@
+package com.ktc.togetherPet.service;
+
+import com.ktc.togetherPet.repository.ReportRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+
+    public ReportService(ReportRepository reportRepository) {
+        this.reportRepository = reportRepository;
+    }
+}

--- a/src/main/java/com/ktc/togetherPet/service/SuspectService.java
+++ b/src/main/java/com/ktc/togetherPet/service/SuspectService.java
@@ -36,6 +36,16 @@ public class SuspectService {
         Long reportId = reportService.createReport(user, suspectRequestDTO);
         imageService.saveImages(reportId, files);
 
+        if (suspectRequestDTO.breed() != null) {
+            reportService.setBreed(reportId, suspectRequestDTO.breed());
+        }
+        if (suspectRequestDTO.color() != null) {
+            reportService.setColor(reportId, suspectRequestDTO.color());
+        }
+        if (suspectRequestDTO.missingId() != null) {
+            reportService.setMissing(reportId, suspectRequestDTO.missingId());
+        }
+
         /** todo: Report 엔티티에 species / color 값이 nullable로 추가되어야 함
          */
 

--- a/src/main/java/com/ktc/togetherPet/service/SuspectService.java
+++ b/src/main/java/com/ktc/togetherPet/service/SuspectService.java
@@ -29,11 +29,12 @@ public class SuspectService {
     }
 
     @Transactional
-    public void createMissing(OauthUserDTO oauthUserDTO, SuspectRequestDTO suspectRequestDTO, List<MultipartFile> files) {
+    public void createMissing(OauthUserDTO oauthUserDTO, SuspectRequestDTO suspectRequestDTO, List<MultipartFile> files) throws IOException {
         User user = userRepository.findByEmail(oauthUserDTO.email())
             .orElseThrow(CustomException::invalidUserException);
 
         Long reportId = reportService.createReport(user, suspectRequestDTO);
+        imageService.saveImages(reportId, files);
 
         /** todo: Report 엔티티에 species / color 값이 nullable로 추가되어야 함
          */

--- a/src/main/java/com/ktc/togetherPet/service/SuspectService.java
+++ b/src/main/java/com/ktc/togetherPet/service/SuspectService.java
@@ -1,8 +1,13 @@
 package com.ktc.togetherPet.service;
 
+import com.ktc.togetherPet.exception.CustomException;
+import com.ktc.togetherPet.model.dto.oauth.OauthUserDTO;
 import com.ktc.togetherPet.model.dto.suspect.SuspectRequestDTO;
 import com.ktc.togetherPet.model.entity.Report;
+import com.ktc.togetherPet.model.entity.User;
 import com.ktc.togetherPet.repository.ReportRepository;
+import com.ktc.togetherPet.repository.UserRepository;
+import java.io.IOException;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,13 +17,24 @@ import org.springframework.web.multipart.MultipartFile;
 public class SuspectService {
 
     private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+    private final ImageService imageService;
+    private final ReportService reportService;
 
-    public SuspectService(ReportRepository reportRepository) {
+    public SuspectService(ReportRepository reportRepository, UserRepository userRepository, ImageService imageService, ReportService reportService) {
         this.reportRepository = reportRepository;
+        this.userRepository = userRepository;
+        this.imageService = imageService;
+        this.reportService = reportService;
     }
 
     @Transactional
-    public void createMissing(SuspectRequestDTO suspectRequestDTO, List<MultipartFile> files) {
+    public void createMissing(OauthUserDTO oauthUserDTO, SuspectRequestDTO suspectRequestDTO, List<MultipartFile> files) {
+        User user = userRepository.findByEmail(oauthUserDTO.email())
+            .orElseThrow(CustomException::invalidUserException);
+
+        Long reportId = reportService.createReport(user, suspectRequestDTO);
+
         /** todo: Report 엔티티에 species / color 값이 nullable로 추가되어야 함
          */
 


### PR DESCRIPTION
## 📋 작업 개요
실종의심신고 구현을 했습니다.

## 📝 작업 상세 설명
Report Service 생성,
SuspectService를 통해 Report와 image를 저장
todo: image를 저장할 때 entity_id를 사용하도록 변경해야함 (이 부분은 합의가 필요)

### ✅ 체크리스트
- [ ] 모든 테스트를 통과했나요?
- [x] 커밋 컨벤션에 맞춰서 작성 했나요?
- [x] PR을 요청할 브랜치를 제대로 선택했나요?
- [x] 이전의 업데이트 사항을 전부 반영했나요?

### 🔗 관련 이슈
#17 

### 📚 참고 사항
https://github.com/kakao-tech-campus-2nd-step3/Team27_BE/commit/fe79956083d4f5036249f980712b48d8467d05c3
