### PR TITLE
실종 의심 동물 나열 기능 및 디테일 확인 기능 추가

### DIFF
--- a/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
+++ b/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
@@ -33,7 +33,7 @@ public class SuspectController {
         @RequestPart(required = false) List<MultipartFile> files,
         @OauthUser OauthUserDTO oauthUserDTO
         ) throws IOException {
-        suspectService.createMissing(oauthUserDTO, suspectRequestDTO, files);
+        suspectService.createSuspectReport(oauthUserDTO, suspectRequestDTO, files);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
+++ b/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
@@ -10,8 +10,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -34,5 +36,16 @@ public class SuspectController {
         suspectService.createMissing(oauthUserDTO, suspectRequestDTO, files);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping
+    //todo: tempDTO를 정의해야 함
+    public ResponseEntity<List<tempDTO>> getSuspectReportsNearByRegion(
+        @RequestParam("latitude") float latitude,
+        @RequestParam("longitude") float longitude
+        ) {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(suspectService.getSuspectReportsNearBy(latitude, longitude));
     }
 }

--- a/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
+++ b/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
@@ -2,16 +2,19 @@ package com.ktc.togetherPet.controller;
 
 import com.ktc.togetherPet.annotation.OauthUser;
 import com.ktc.togetherPet.model.dto.oauth.OauthUserDTO;
+import com.ktc.togetherPet.model.dto.suspect.ReportDetailDTO;
 import com.ktc.togetherPet.model.dto.suspect.ReportNearByDTO;
 import com.ktc.togetherPet.model.dto.suspect.SuspectRequestDTO;
 import com.ktc.togetherPet.service.SuspectService;
 import java.io.IOException;
 import java.util.List;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -47,5 +50,14 @@ public class SuspectController {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(suspectService.getSuspectReportsNearBy(latitude, longitude));
+    }
+
+    @GetMapping("/{report-id}")
+    public ResponseEntity<ReportDetailDTO> getSuspectReportDetailByReportId(
+        @PathVariable("report-id") long reportId
+        ) {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(suspectService.getSuspectReportDetailByReportId(reportId));
     }
 }

--- a/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
+++ b/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
@@ -2,6 +2,7 @@ package com.ktc.togetherPet.controller;
 
 import com.ktc.togetherPet.annotation.OauthUser;
 import com.ktc.togetherPet.model.dto.oauth.OauthUserDTO;
+import com.ktc.togetherPet.model.dto.suspect.ReportNearByDTO;
 import com.ktc.togetherPet.model.dto.suspect.SuspectRequestDTO;
 import com.ktc.togetherPet.service.SuspectService;
 import java.io.IOException;
@@ -39,8 +40,7 @@ public class SuspectController {
     }
 
     @GetMapping
-    //todo: tempDTO를 정의해야 함
-    public ResponseEntity<List<tempDTO>> getSuspectReportsNearByRegion(
+    public ResponseEntity<List<ReportNearByDTO>> getSuspectReportsNearByRegion(
         @RequestParam("latitude") float latitude,
         @RequestParam("longitude") float longitude
         ) {

--- a/src/main/java/com/ktc/togetherPet/exception/CustomException.java
+++ b/src/main/java/com/ktc/togetherPet/exception/CustomException.java
@@ -2,6 +2,7 @@ package com.ktc.togetherPet.exception;
 
 import static com.ktc.togetherPet.exception.ErrorMessage.BREED_NOT_FOUND;
 import static com.ktc.togetherPet.exception.ErrorMessage.EXPIRED_TOKEN;
+import static com.ktc.togetherPet.exception.ErrorMessage.IMAGE_NOT_FOUND;
 import static com.ktc.togetherPet.exception.ErrorMessage.INVALID_DATE;
 import static com.ktc.togetherPet.exception.ErrorMessage.INVALID_LOCATION;
 import static com.ktc.togetherPet.exception.ErrorMessage.INVALID_PET_MONTH;
@@ -78,5 +79,9 @@ public class CustomException extends RuntimeException {
 
     public static CustomException missingNotFound(){
         return new CustomException(MISSING_NOT_FOUND, NOT_FOUND);
+    }
+
+    public static CustomException imageNotFoundException(){
+        return new CustomException(IMAGE_NOT_FOUND, NOT_FOUND);
     }
 }

--- a/src/main/java/com/ktc/togetherPet/exception/ErrorMessage.java
+++ b/src/main/java/com/ktc/togetherPet/exception/ErrorMessage.java
@@ -15,4 +15,5 @@ public class ErrorMessage {
     public static final String PET_NOT_FOUND = "해당 펫을 찾을 수 없습니다.";
     public static final String MISSING_NOT_FOUND = "해당 실종 정보를 찾을 수 없습니다.";
     public static final String REPORT_NOT_FOUND = "해당 신고 정보를 찾을 수 없습니다.";
+    public static final String IMAGE_NOT_FOUND = "해당 이미지를 찾을 수 없습니다.";
 }

--- a/src/main/java/com/ktc/togetherPet/model/dto/suspect/ReportDetailDTO.java
+++ b/src/main/java/com/ktc/togetherPet/model/dto/suspect/ReportDetailDTO.java
@@ -1,0 +1,21 @@
+package com.ktc.togetherPet.model.dto.suspect;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record ReportDetailDTO(
+    String petBreed,
+    String petColor,
+    String petGender,
+    float latitude,
+    float longitude,
+    String description,
+    String reporterName,
+    List<String> imageUrl,
+    LocalDateTime foundDate
+) {
+
+}

--- a/src/main/java/com/ktc/togetherPet/model/dto/suspect/ReportDetailDTO.java
+++ b/src/main/java/com/ktc/togetherPet/model/dto/suspect/ReportDetailDTO.java
@@ -1,5 +1,6 @@
 package com.ktc.togetherPet.model.dto.suspect;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.time.LocalDateTime;
@@ -15,6 +16,7 @@ public record ReportDetailDTO(
     String description,
     String reporterName,
     List<String> imageUrl,
+    @JsonFormat(pattern = "yyyy.MM.dd (E) HH:mm", timezone = "Asia/Seoul")
     LocalDateTime foundDate
 ) {
 

--- a/src/main/java/com/ktc/togetherPet/model/dto/suspect/ReportNearByDTO.java
+++ b/src/main/java/com/ktc/togetherPet/model/dto/suspect/ReportNearByDTO.java
@@ -1,0 +1,13 @@
+package com.ktc.togetherPet.model.dto.suspect;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record ReportNearByDTO (
+    float latitude,
+    float longitude,
+    String reportRepImageUrl
+) {
+
+}

--- a/src/main/java/com/ktc/togetherPet/model/dto/suspect/ReportNearByDTO.java
+++ b/src/main/java/com/ktc/togetherPet/model/dto/suspect/ReportNearByDTO.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record ReportNearByDTO (
+    long reportId,
     float latitude,
     float longitude,
     String reportRepImageUrl

--- a/src/main/java/com/ktc/togetherPet/model/dto/suspect/SuspectRequestDTO.java
+++ b/src/main/java/com/ktc/togetherPet/model/dto/suspect/SuspectRequestDTO.java
@@ -17,6 +17,8 @@ public record SuspectRequestDTO(
     @NotNull
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     LocalDateTime foundDate,
+    @NotNull
+    String description,
 
     String breed,
     String gender,

--- a/src/main/java/com/ktc/togetherPet/model/entity/Image.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/Image.java
@@ -24,4 +24,8 @@ public class Image {
     public Image(String path) {
         this.path = path;
     }
+
+    public String getPath() {
+        return path;
+    }
 }

--- a/src/main/java/com/ktc/togetherPet/model/entity/ImageRelation/ImageRelation.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/ImageRelation/ImageRelation.java
@@ -47,4 +47,8 @@ public class ImageRelation {
         this.imageEntityType = imageEntityType;
         this.image = image;
     }
+
+    public Image getImage() {
+        return image;
+    }
 }

--- a/src/main/java/com/ktc/togetherPet/model/entity/ImageRelation/ImageRelation.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/ImageRelation/ImageRelation.java
@@ -31,10 +31,10 @@ public class ImageRelation {
     @JoinColumn(name = "report_id", nullable = true)
     private Report report;
 
-    /**todo: Report, Pet, Missing 연관 관계를 entity_id로 통합 관리하도록 해야함
+    // todo: Report, Pet, Missing 연관 관계를 entity_id로 통합 관리하도록 해야함
     @Column(name = "entity_id", nullable = false)
     private Long entityId;
-     **/
+
 
     @ManyToOne(targetEntity = Image.class)
     @JoinColumn(name = "image_id", nullable = false)

--- a/src/main/java/com/ktc/togetherPet/model/entity/Report.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/Report.java
@@ -45,6 +45,9 @@ public class Report {
     @JoinColumn(name = "missing_id", nullable = true)
     private Missing missing;
 
+    @Column(name = "description", nullable = false)
+    private String description;
+
     public Long getId() {
         return id;
     }
@@ -68,10 +71,11 @@ public class Report {
     public Report() {
     }
 
-    public Report(User user, LocalDateTime timestamp, Location location, long regionCode) {
+    public Report(User user, LocalDateTime timestamp, Location location, long regionCode, String description) {
         this.user = user;
         this.timeStamp = timestamp;
         this.location = location;
         this.regionCode = regionCode;
+        this.description = description;
     }
 }

--- a/src/main/java/com/ktc/togetherPet/model/entity/Report.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/Report.java
@@ -48,6 +48,9 @@ public class Report {
     @Column(name = "description", nullable = false)
     private String description;
 
+    @Column(name = "gender", nullable = false)
+    private String gender;
+
     public Long getId() {
         return id;
     }
@@ -56,12 +59,36 @@ public class Report {
         return location;
     }
 
+    public Breed getBreed() {
+        return breed;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public String getGender() {
+        return gender;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public LocalDateTime getTimeStamp() {
+        return timeStamp;
+    }
+
     public void setBreed(Breed breed) {
         this.breed = breed;
     }
 
-    public void setColor(String color) {
-        this.color = color;
+    public void setGender(String gender) {
+        this.gender = gender;
     }
 
     public void setMissing(Missing missing) {

--- a/src/main/java/com/ktc/togetherPet/model/entity/Report.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/Report.java
@@ -49,6 +49,10 @@ public class Report {
         return id;
     }
 
+    public Location getLocation() {
+        return location;
+    }
+
     public void setBreed(Breed breed) {
         this.breed = breed;
     }

--- a/src/main/java/com/ktc/togetherPet/model/entity/Report.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/Report.java
@@ -31,6 +31,9 @@ public class Report {
     @Embedded
     private Location location;
 
+    @Column(name = "region_code", nullable = false)
+    private long regionCode;
+
     @Column(name = "color", nullable = true)
     private String color;
 
@@ -61,9 +64,10 @@ public class Report {
     public Report() {
     }
 
-    public Report(User user, LocalDateTime timestamp, Location location) {
+    public Report(User user, LocalDateTime timestamp, Location location, long regionCode) {
         this.user = user;
         this.timeStamp = timestamp;
         this.location = location;
+        this.regionCode = regionCode;
     }
 }

--- a/src/main/java/com/ktc/togetherPet/model/entity/User.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/User.java
@@ -46,6 +46,9 @@ public class User {
         this.pet = pet;
     }
 
+    public String getName() {
+        return name;
+    }
     public Pet getPet() {
         return pet;
     }

--- a/src/main/java/com/ktc/togetherPet/repository/ImageRelationRepository.java
+++ b/src/main/java/com/ktc/togetherPet/repository/ImageRelationRepository.java
@@ -2,12 +2,12 @@ package com.ktc.togetherPet.repository;
 
 import com.ktc.togetherPet.model.entity.ImageRelation.ImageEntityType;
 import com.ktc.togetherPet.model.entity.ImageRelation.ImageRelation;
-import java.util.Optional;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ImageRelationRepository extends JpaRepository<ImageRelation, Long> {
 
-    Optional<ImageRelation> findByImageEntityTypeAndEntityId(ImageEntityType imageEntityType, Long entityId);
+    List<ImageRelation> findByImageEntityTypeAndEntityId(ImageEntityType imageEntityType, Long entityId);
 }

--- a/src/main/java/com/ktc/togetherPet/repository/ImageRelationRepository.java
+++ b/src/main/java/com/ktc/togetherPet/repository/ImageRelationRepository.java
@@ -1,10 +1,13 @@
 package com.ktc.togetherPet.repository;
 
+import com.ktc.togetherPet.model.entity.ImageRelation.ImageEntityType;
 import com.ktc.togetherPet.model.entity.ImageRelation.ImageRelation;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ImageRelationRepository extends JpaRepository<ImageRelation, Long> {
 
+    Optional<ImageRelation> findByImageEntityTypeAndEntityId(ImageEntityType imageEntityType, Long entityId);
 }

--- a/src/main/java/com/ktc/togetherPet/repository/ReportRepository.java
+++ b/src/main/java/com/ktc/togetherPet/repository/ReportRepository.java
@@ -1,11 +1,12 @@
 package com.ktc.togetherPet.repository;
 
 import com.ktc.togetherPet.model.entity.Report;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
-
+    List<Report> findAllByRegionCode(long regionCode);
 }

--- a/src/main/java/com/ktc/togetherPet/service/ImageService.java
+++ b/src/main/java/com/ktc/togetherPet/service/ImageService.java
@@ -80,6 +80,15 @@ public class ImageService {
         }
     }
 
+    public String getRepresentativeImageById(ImageEntityType entityType,Long Id) {
+        List<ImageRelation> imageRelations = imageRelationRepository.findByImageEntityTypeAndEntityId(entityType, Id);
+
+        return imageRelations.stream()
+            .findFirst()
+            .map(imageRelation -> imageRelation.getImage().getPath())
+            .orElseThrow(CustomException::imageNotFoundException);
+    }
+
     private String getFileExtension(String filename) {
         if (filename != null && filename.contains(".")) {
             return filename.substring(filename.lastIndexOf("."));

--- a/src/main/java/com/ktc/togetherPet/service/ImageService.java
+++ b/src/main/java/com/ktc/togetherPet/service/ImageService.java
@@ -80,8 +80,14 @@ public class ImageService {
         }
     }
 
-    public String getRepresentativeImageById(ImageEntityType entityType,Long Id) {
+    public List<ImageRelation> getImageRelationsById(ImageEntityType entityType, Long Id) {
         List<ImageRelation> imageRelations = imageRelationRepository.findByImageEntityTypeAndEntityId(entityType, Id);
+
+        return imageRelations;
+    }
+
+    public String getRepresentativeImageById(ImageEntityType entityType,Long Id) {
+        List<ImageRelation> imageRelations = getImageRelationsById(entityType, Id);
 
         return imageRelations.stream()
             .findFirst()

--- a/src/main/java/com/ktc/togetherPet/service/ReportService.java
+++ b/src/main/java/com/ktc/togetherPet/service/ReportService.java
@@ -1,14 +1,18 @@
 package com.ktc.togetherPet.service;
 
 import com.ktc.togetherPet.exception.CustomException;
+import com.ktc.togetherPet.model.dto.suspect.ReportNearByDTO;
 import com.ktc.togetherPet.model.dto.suspect.SuspectRequestDTO;
 import com.ktc.togetherPet.model.entity.Breed;
+import com.ktc.togetherPet.model.entity.ImageRelation.ImageEntityType;
 import com.ktc.togetherPet.model.entity.Missing;
 import com.ktc.togetherPet.model.entity.Report;
 import com.ktc.togetherPet.model.entity.User;
 import com.ktc.togetherPet.model.vo.Location;
 import com.ktc.togetherPet.repository.MissingRepository;
 import com.ktc.togetherPet.repository.ReportRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,11 +21,14 @@ public class ReportService {
     private final ReportRepository reportRepository;
     private final MissingRepository missingRepository;
     private final KakaoMapService kakaoMapService;
+    private final ImageService imageService;
 
-    public ReportService(ReportRepository reportRepository, MissingRepository missingRepository, KakaoMapService kakaoMapService) {
+    public ReportService(ReportRepository reportRepository, MissingRepository missingRepository, KakaoMapService kakaoMapService,
+        ImageService imageService) {
         this.reportRepository = reportRepository;
         this.missingRepository = missingRepository;
         this.kakaoMapService = kakaoMapService;
+        this.imageService = imageService;
     }
 
     public Long createReport(User user, SuspectRequestDTO suspectRequestDTO) {
@@ -41,6 +48,29 @@ public class ReportService {
         );
 
         return report.getId();
+    }
+
+    public List<ReportNearByDTO> getReportsByLocation(float latitude, float longitude) {
+        Location location = new Location(latitude, longitude);
+        long regionCode = kakaoMapService.getRegionCodeFromKakao(location);
+
+        /** XXX: 이 부분 missing이 null인 경우에 받을 지 아니면 전체 리포트를 받을 지 상의 필요
+            * missing이 null인 것만 받아옴 = 실종신고자에게 제보한 것은 제외함 = findAllByRegionCodeAndMissingNotNull
+            * 전체 리포트를 받아옴 = 실종신고자에게 제보한 것도 포함함 = findAllByRegionCode
+         **/
+        return reportRepository.findAllByRegionCode(regionCode)
+            .stream()
+            .map(report -> {
+                    String representImagePath = imageService.getRepresentativeImageById(ImageEntityType.REPORT, report.getId());
+                    return new ReportNearByDTO(
+                        report.getId(),
+                        report.getLocation().getLatitude(),
+                        report.getLocation().getLongitude(),
+                        representImagePath
+                    );
+            })
+            .collect(Collectors.toList());
+
     }
 
     public void setBreed(Long reportId, String breed) {

--- a/src/main/java/com/ktc/togetherPet/service/ReportService.java
+++ b/src/main/java/com/ktc/togetherPet/service/ReportService.java
@@ -43,7 +43,8 @@ public class ReportService {
                 user,
                 suspectRequestDTO.foundDate(),
                 location,
-                kakaoMapService.getRegionCodeFromKakao(location)
+                kakaoMapService.getRegionCodeFromKakao(location),
+                suspectRequestDTO.description()
             )
         );
 

--- a/src/main/java/com/ktc/togetherPet/service/ReportService.java
+++ b/src/main/java/com/ktc/togetherPet/service/ReportService.java
@@ -1,6 +1,7 @@
 package com.ktc.togetherPet.service;
 
 import com.ktc.togetherPet.exception.CustomException;
+import com.ktc.togetherPet.model.dto.suspect.ReportDetailDTO;
 import com.ktc.togetherPet.model.dto.suspect.ReportNearByDTO;
 import com.ktc.togetherPet.model.dto.suspect.SuspectRequestDTO;
 import com.ktc.togetherPet.model.entity.Breed;
@@ -74,6 +75,28 @@ public class ReportService {
 
     }
 
+    public ReportDetailDTO getReportById(long reportId) {
+        Report report = reportRepository.findById(reportId)
+            .orElseThrow(CustomException::reportNotFoundException);
+
+        Location location = report.getLocation();
+
+        return new ReportDetailDTO(
+            report.getBreed().getName(),
+            report.getColor(),
+            report.getGender(),
+            location.getLatitude(),
+            location.getLongitude(),
+            report.getDescription(),
+            report.getUser().getName(),
+            imageService.getImageRelationsById(ImageEntityType.REPORT, reportId)
+                .stream()
+                .map(imageRelation -> imageRelation.getImage().getPath())
+                .collect(Collectors.toList()),
+            report.getTimeStamp()
+        );
+    }
+
     public void setBreed(Long reportId, String breed) {
         Report report = reportRepository.findById(reportId)
             .orElseThrow(CustomException::reportNotFoundException);
@@ -84,11 +107,11 @@ public class ReportService {
         reportRepository.save(report);
     }
 
-    public void setColor(Long reportId, String color) {
+    public void setGender(Long reportId, String gender) {
         Report report = reportRepository.findById(reportId)
             .orElseThrow(CustomException::reportNotFoundException);
 
-        report.setColor(color);
+        report.setGender(gender);
 
         reportRepository.save(report);
     }

--- a/src/main/java/com/ktc/togetherPet/service/ReportService.java
+++ b/src/main/java/com/ktc/togetherPet/service/ReportService.java
@@ -16,10 +16,12 @@ public class ReportService {
 
     private final ReportRepository reportRepository;
     private final MissingRepository missingRepository;
+    private final KakaoMapService kakaoMapService;
 
-    public ReportService(ReportRepository reportRepository, MissingRepository missingRepository) {
+    public ReportService(ReportRepository reportRepository, MissingRepository missingRepository, KakaoMapService kakaoMapService) {
         this.reportRepository = reportRepository;
         this.missingRepository = missingRepository;
+        this.kakaoMapService = kakaoMapService;
     }
 
     public Long createReport(User user, SuspectRequestDTO suspectRequestDTO) {
@@ -33,7 +35,8 @@ public class ReportService {
             new Report(
                 user,
                 suspectRequestDTO.foundDate(),
-                location
+                location,
+                kakaoMapService.getRegionCodeFromKakao(location)
             )
         );
 

--- a/src/main/java/com/ktc/togetherPet/service/SuspectService.java
+++ b/src/main/java/com/ktc/togetherPet/service/SuspectService.java
@@ -2,6 +2,7 @@ package com.ktc.togetherPet.service;
 
 import com.ktc.togetherPet.exception.CustomException;
 import com.ktc.togetherPet.model.dto.oauth.OauthUserDTO;
+import com.ktc.togetherPet.model.dto.suspect.ReportDetailDTO;
 import com.ktc.togetherPet.model.dto.suspect.ReportNearByDTO;
 import com.ktc.togetherPet.model.dto.suspect.SuspectRequestDTO;
 import com.ktc.togetherPet.model.entity.Report;
@@ -37,11 +38,12 @@ public class SuspectService {
         Long reportId = reportService.createReport(user, suspectRequestDTO);
         imageService.saveImages(reportId, files);
 
+        //todo: Optional.ofNullable 을 사용하는 것으로 변경
         if (suspectRequestDTO.breed() != null) {
             reportService.setBreed(reportId, suspectRequestDTO.breed());
         }
-        if (suspectRequestDTO.color() != null) {
-            reportService.setColor(reportId, suspectRequestDTO.color());
+        if (suspectRequestDTO.gender() != null) {
+            reportService.setGender(reportId, suspectRequestDTO.gender());
         }
         if (suspectRequestDTO.missingId() != null) {
             reportService.setMissing(reportId, suspectRequestDTO.missingId());
@@ -56,5 +58,9 @@ public class SuspectService {
     public List<ReportNearByDTO> getSuspectReportsNearBy(float latitude, float longitude) {
 
         return reportService.getReportsByLocation(latitude, longitude);
+    }
+
+    public ReportDetailDTO getSuspectReportDetailByReportId(long reportId) {
+        return reportService.getReportById(reportId);
     }
 }

--- a/src/main/java/com/ktc/togetherPet/service/SuspectService.java
+++ b/src/main/java/com/ktc/togetherPet/service/SuspectService.java
@@ -29,7 +29,7 @@ public class SuspectService {
     }
 
     @Transactional
-    public void createMissing(OauthUserDTO oauthUserDTO, SuspectRequestDTO suspectRequestDTO, List<MultipartFile> files) throws IOException {
+    public void createSuspectReport(OauthUserDTO oauthUserDTO, SuspectRequestDTO suspectRequestDTO, List<MultipartFile> files) throws IOException {
         User user = userRepository.findByEmail(oauthUserDTO.email())
             .orElseThrow(CustomException::invalidUserException);
 

--- a/src/main/java/com/ktc/togetherPet/service/SuspectService.java
+++ b/src/main/java/com/ktc/togetherPet/service/SuspectService.java
@@ -2,6 +2,7 @@ package com.ktc.togetherPet.service;
 
 import com.ktc.togetherPet.exception.CustomException;
 import com.ktc.togetherPet.model.dto.oauth.OauthUserDTO;
+import com.ktc.togetherPet.model.dto.suspect.ReportNearByDTO;
 import com.ktc.togetherPet.model.dto.suspect.SuspectRequestDTO;
 import com.ktc.togetherPet.model.entity.Report;
 import com.ktc.togetherPet.model.entity.User;
@@ -50,5 +51,10 @@ public class SuspectService {
          */
 
         Report report = new Report();
+    }
+
+    public List<ReportNearByDTO> getSuspectReportsNearBy(float latitude, float longitude) {
+
+        return reportService.getReportsByLocation(latitude, longitude);
     }
 }


### PR DESCRIPTION
## 📋 작업 개요
실종 의심 동물 나열 기능 및 디테일 확인 기능 추가

## 📝 작업 상세 설명
실종 의심동물 나열 기능과
디테일을 확인할 수 있는 기능들을 컨벤션에 맞게 추가했습니다.
imagePath 받아오는 부분도 구현해놨습니다

### ✅ 체크리스트
- [ ] 모든 테스트를 통과했나요?
- [x] 커밋 컨벤션에 맞춰서 작성 했나요?
- [x] PR을 요청할 브랜치를 제대로 선택했나요?
- [x] 이전의 업데이트 사항을 전부 반영했나요?

### 🔗 관련 이슈
#19 
#18 

### 📚 참고 사항

