### PR TITLE
응답의 보일러 플레이트 제거

### DIFF
--- a/src/main/java/com/ktc/togetherPet/apiResponse/CustomResponse.java
+++ b/src/main/java/com/ktc/togetherPet/apiResponse/CustomResponse.java
@@ -1,0 +1,33 @@
+package com.ktc.togetherPet.apiResponse;
+
+import com.ktc.togetherPet.model.dto.oauth.OauthSuccessDTO;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class CustomResponse {
+    public static ResponseEntity<?> oauthSuccess(OauthSuccessDTO oauthSuccessDTO) {
+        return ResponseEntity
+            .status(oauthSuccessDTO.status())
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + oauthSuccessDTO.jwtToken())
+            .build();
+    }
+
+    public static <T> ResponseEntity<T> ok(HttpHeaders headers, T body) {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .headers(headers)
+            .body(body);
+    }
+
+    public static <T> ResponseEntity<T> ok(T body) {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(body);
+    }
+
+    public static ResponseEntity<?> created() {
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+}

--- a/src/main/java/com/ktc/togetherPet/controller/ImageController.java
+++ b/src/main/java/com/ktc/togetherPet/controller/ImageController.java
@@ -1,8 +1,8 @@
 package com.ktc.togetherPet.controller;
 
-import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.IMAGE_JPEG;
 
+import com.ktc.togetherPet.apiResponse.CustomResponse;
 import com.ktc.togetherPet.service.ImageService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -28,9 +28,6 @@ public class ImageController {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(IMAGE_JPEG);
 
-        return ResponseEntity
-            .status(OK)
-            .headers(headers)
-            .body(imageService.getImageBytesFromFileName(fileName));
+        return CustomResponse.ok(headers, imageService.getImageBytesFromFileName(fileName));
     }
 }

--- a/src/main/java/com/ktc/togetherPet/controller/MissingController.java
+++ b/src/main/java/com/ktc/togetherPet/controller/MissingController.java
@@ -1,9 +1,7 @@
 package com.ktc.togetherPet.controller;
 
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.OK;
-
 import com.ktc.togetherPet.annotation.OauthUser;
+import com.ktc.togetherPet.apiResponse.CustomResponse;
 import com.ktc.togetherPet.model.dto.missing.MissingPetDetailResponseDTO;
 import com.ktc.togetherPet.model.dto.missing.MissingPetNearByResponseDTO;
 import com.ktc.togetherPet.model.dto.missing.MissingPetRequestDTO;
@@ -35,13 +33,13 @@ public class MissingController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> registerMissingPet(
+    public ResponseEntity<?> registerMissingPet(
         @OauthUser OauthUserDTO oauthUserDTO,
         @RequestBody MissingPetRequestDTO missingPetRequestDTO
     ) {
 
         missingService.registerMissingPet(oauthUserDTO, missingPetRequestDTO);
-        return ResponseEntity.status(CREATED).build();
+        return CustomResponse.created();
     }
 
     @GetMapping
@@ -49,35 +47,27 @@ public class MissingController {
         @RequestParam("latitude") double latitude,
         @RequestParam("longitude") double longitude
     ) {
-        return ResponseEntity
-            .status(OK)
-            .body(missingService.getMissingPetsNearBy(latitude, longitude));
+        return CustomResponse.ok(missingService.getMissingPetsNearBy(latitude, longitude));
     }
 
     @GetMapping("/{missing-id}")
     public ResponseEntity<MissingPetDetailResponseDTO> getMissingPetDetailByMissingId(
         @PathVariable("missing-id") long missingId
     ) {
-        return ResponseEntity
-            .status(OK)
-            .body(missingService.getMissingPetDetailByMissingId(missingId));
+        return CustomResponse.ok(missingService.getMissingPetDetailByMissingId(missingId));
     }
 
     @GetMapping("/report")
     public ResponseEntity<List<ReportResponseDTO>> getMissingReports(
         @OauthUser OauthUserDTO oauthUserDTO
     ) {
-        return ResponseEntity
-            .status(OK)
-            .body(missingService.getMissingReports(oauthUserDTO));
+        return CustomResponse.ok(missingService.getMissingReports(oauthUserDTO));
     }
 
     @GetMapping("/report/{report-id}")
     public ResponseEntity<ReportDetailResponseDTO> getMissingReportDetailByReportId(
         @PathVariable("report-id") long reportId
     ) {
-        return ResponseEntity
-            .status(OK)
-            .body(missingService.getReportDetail(reportId));
+        return CustomResponse.ok(missingService.getReportDetail(reportId));
     }
 }

--- a/src/main/java/com/ktc/togetherPet/controller/OauthController.java
+++ b/src/main/java/com/ktc/togetherPet/controller/OauthController.java
@@ -1,12 +1,12 @@
 package com.ktc.togetherPet.controller;
 
+import com.ktc.togetherPet.apiResponse.CustomResponse;
 import com.ktc.togetherPet.exception.CustomException;
+import com.ktc.togetherPet.model.dto.oauth.OauthSuccessDTO;
 import com.ktc.togetherPet.service.OauthService;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -20,19 +20,16 @@ public class OauthController {
         this.oauthService = oauthService;
     }
 
-    @GetMapping("/{provider}")
-    public ResponseEntity<?> handleOauth(@RequestHeader("Authorization") String authorizationHeader,
-        @PathVariable String provider) {
+    @GetMapping
+    public ResponseEntity<?> handleOauth(@RequestHeader("Authorization") String authorizationHeader) {
 
-        String accessToken = extractAccessToken(authorizationHeader);
-        String jwtToken = oauthService.processOauth(provider, accessToken);
+        String email = extractEmail(authorizationHeader);
+        OauthSuccessDTO oauthSuccessDTO = oauthService.processOauth(email);
 
-        return ResponseEntity.ok()
-            .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken)
-            .build();
+        return CustomResponse.oauthSuccess(oauthSuccessDTO);
     }
 
-    private String extractAccessToken(String authorizationHeader) {
+    private String extractEmail(String authorizationHeader) {
         if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
             return authorizationHeader.replace("Bearer ", "");
         }

--- a/src/main/java/com/ktc/togetherPet/controller/RegisterController.java
+++ b/src/main/java/com/ktc/togetherPet/controller/RegisterController.java
@@ -1,10 +1,10 @@
 package com.ktc.togetherPet.controller;
 
 import com.ktc.togetherPet.annotation.OauthUser;
+import com.ktc.togetherPet.apiResponse.CustomResponse;
 import com.ktc.togetherPet.model.dto.oauth.OauthUserDTO;
 import com.ktc.togetherPet.model.dto.pet.PetRegisterRequestDTO;
 import com.ktc.togetherPet.service.RegisterService;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,6 +30,6 @@ public class RegisterController {
         @OauthUser OauthUserDTO oauthUserDTO) {
         registerService.create(petRegisterRequestDTO, petImage, oauthUserDTO.email(), userName);
 
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return CustomResponse.created();
     }
 }

--- a/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
+++ b/src/main/java/com/ktc/togetherPet/controller/SuspectController.java
@@ -1,13 +1,13 @@
 package com.ktc.togetherPet.controller;
 
 import com.ktc.togetherPet.annotation.OauthUser;
+import com.ktc.togetherPet.apiResponse.CustomResponse;
 import com.ktc.togetherPet.model.dto.oauth.OauthUserDTO;
 import com.ktc.togetherPet.model.dto.suspect.ReportDetailResponseDTO;
 import com.ktc.togetherPet.model.dto.suspect.ReportNearByResponseDTO;
 import com.ktc.togetherPet.model.dto.suspect.SuspectRequestDTO;
 import com.ktc.togetherPet.service.SuspectService;
 import java.util.List;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -37,7 +37,7 @@ public class SuspectController {
     ) {
         suspectService.createSuspectReport(oauthUserDTO, suspectRequestDTO, files);
 
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return CustomResponse.created();
     }
 
     @GetMapping
@@ -45,17 +45,13 @@ public class SuspectController {
         @RequestParam("latitude") double latitude,
         @RequestParam("longitude") double longitude
     ) {
-        return ResponseEntity
-            .status(HttpStatus.OK)
-            .body(suspectService.getSuspectReportsNearBy(latitude, longitude));
+        return CustomResponse.ok(suspectService.getSuspectReportsNearBy(latitude, longitude));
     }
 
     @GetMapping("/{report-id}")
     public ResponseEntity<ReportDetailResponseDTO> getSuspectReportDetailByReportId(
         @PathVariable("report-id") long reportId
     ) {
-        return ResponseEntity
-            .status(HttpStatus.OK)
-            .body(suspectService.getSuspectReportDetailByReportId(reportId));
+        return CustomResponse.ok(suspectService.getSuspectReportDetailByReportId(reportId));
     }
 }

--- a/src/main/java/com/ktc/togetherPet/model/dto/oauth/OauthSuccessDTO.java
+++ b/src/main/java/com/ktc/togetherPet/model/dto/oauth/OauthSuccessDTO.java
@@ -1,0 +1,7 @@
+package com.ktc.togetherPet.model.dto.oauth;
+
+import org.springframework.http.HttpStatus;
+
+public record OauthSuccessDTO(HttpStatus status, String jwtToken) {
+
+}

--- a/src/main/java/com/ktc/togetherPet/model/entity/User.java
+++ b/src/main/java/com/ktc/togetherPet/model/entity/User.java
@@ -24,11 +24,11 @@ public class User {
     private String name;
 
     @ManyToOne(targetEntity = Region.class)
-    @JoinColumn(name = "region_id", nullable = false)
+    @JoinColumn(name = "region_id", nullable = true)
     private Region region;
 
     @ManyToOne(targetEntity = Pet.class)
-    @JoinColumn(name = "pet_id", nullable = false)
+    @JoinColumn(name = "pet_id", nullable = true)
     private Pet pet;
 
     public User() {

--- a/src/main/java/com/ktc/togetherPet/service/OauthService.java
+++ b/src/main/java/com/ktc/togetherPet/service/OauthService.java
@@ -1,7 +1,8 @@
 package com.ktc.togetherPet.service;
 
-import com.ktc.togetherPet.exception.CustomException;
 import com.ktc.togetherPet.jwtUtil.JwtUtil;
+import com.ktc.togetherPet.model.dto.oauth.OauthSuccessDTO;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -9,33 +10,24 @@ public class OauthService {
 
     private final JwtUtil jwtUtil;
     private final UserService userService;
-    private final KakaoOauthService kakaoOauthService;
 
-    public OauthService(JwtUtil jwtUtil, UserService userService,
-        KakaoOauthService kakaoOauthService) {
+    public OauthService(JwtUtil jwtUtil, UserService userService) {
         this.jwtUtil = jwtUtil;
         this.userService = userService;
-        this.kakaoOauthService = kakaoOauthService;
     }
 
-    public String processOauth(String provider, String accessToken) {
-        String email = getEmailFromProvider(provider, accessToken);
-        ensureUserExists(email);
+    public OauthSuccessDTO processOauth(String email) {
+        HttpStatus status = ensureUserExists(email);
 
-        return jwtUtil.makeToken(email);
+        return new OauthSuccessDTO(status, jwtUtil.makeToken(email));
     }
 
-    private void ensureUserExists(String email) {
+    private HttpStatus ensureUserExists(String email) {
         if (!userService.userExists(email)) {
             userService.createUser(email);
-        }
-    }
-
-    private String getEmailFromProvider(String provider, String accessToken) {
-        if (provider.equals("kakao")) {
-            return kakaoOauthService.getEmailFromToken(accessToken);
+            return HttpStatus.CREATED;
         }
 
-        throw CustomException.invalidProviderException();
+        return HttpStatus.OK;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.config.import=classpath:.env.properties
 # jpa
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.hibernate.ddl-auto=create-drop
+#spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.generate-ddl=true
 # mysql
 spring.datasource.url=${database.datasource.url}


### PR DESCRIPTION
## 📋 작업 개요
<!-- 여기에 작업한 내용을 간략하게 요약해 주세요 -->
응답의 보일러 플레이트 제거
## 📝 작업 상세 설명
<!-- 구체적인 변경 사항을 적어주세요 -->
CustomResponse 클래스를 생성하여 응답의 보일러 플레이트를 제거하고 간단하게 응답 ResponseEntity를 생성할 수 있도록 기능을 수정하였다.
### ✅ 체크리스트
- [x] 모든 테스트를 통과했나요?
- [x] 커밋 컨벤션에 맞춰서 작성 했나요?
- [x] PR을 요청할 브랜치를 제대로 선택했나요?
- [x] 이전의 업데이트 사항을 전부 반영했나요?

### 🔗 관련 이슈
<!-- 이슈 번호를 링크하세요: #이슈번호 -->

### 📚 참고 사항
<!-- 리뷰어가 참고할 만한 내용이 있다면 적어주세요 -->
